### PR TITLE
Update build-appimage.yml

### DIFF
--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -175,6 +175,7 @@ jobs:
             qt6-tools-dev-tools \
             libqt6svg6-dev \
             libopencv-dev \
+            qt6-serialport-dev \
             libproc2-dev \
             wget \
             file \


### PR DESCRIPTION
Added, as build dependency, the qt6-serialport-dev package to get the hatire plugin support in Opentrack.